### PR TITLE
Update genre validation check and invalid genre values in tests

### DIFF
--- a/src/main/java/seedu/library/model/bookmark/Genre.java
+++ b/src/main/java/seedu/library/model/bookmark/Genre.java
@@ -9,27 +9,13 @@ import static seedu.library.commons.util.AppUtil.checkArgument;
  */
 public class Genre {
 
-    private static final String SPECIAL_CHARACTERS = "+_.-";
-    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
-            + "and adhere to the following constraints:\n"
-            + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
-            + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
-            + "characters.\n"
-            + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
-            + "separated by periods.\n"
-            + "The domain name must:\n"
-            + "    - end with a domain label at least 2 characters long\n"
-            + "    - have each domain label start and end with alphanumeric characters\n"
-            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
-    // alphanumeric and special characters
-    private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
-    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
-            + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
-            + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
-    public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
+    public static final String MESSAGE_CONSTRAINTS = "Genre can take any values, and it should not be blank";
+
+    /*
+     * The first character of the genre must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String value;
 

--- a/src/test/data/JsonSerializableLibraryTest/invalidBookmarkLibrary.json
+++ b/src/test/data/JsonSerializableLibraryTest/invalidBookmarkLibrary.json
@@ -2,7 +2,7 @@
   "bookmarks": [ {
     "title": "Hans Muster",
     "phone": "9482424",
-    "genre": "invalid@email!3e",
+    "genre": " ",
     "author": "4th street"
   } ]
 }

--- a/src/test/java/seedu/library/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/library/logic/commands/CommandTestUtil.java
@@ -30,8 +30,8 @@ public class CommandTestUtil {
     public static final String VALID_TITLE_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";
     public static final String VALID_PHONE_BOB = "22222222";
-    public static final String VALID_GENRE_AMY = "amy@example.com";
-    public static final String VALID_GENRE_BOB = "bob@example.com";
+    public static final String VALID_GENRE_AMY = "Amy";
+    public static final String VALID_GENRE_BOB = "Bob";
     public static final String VALID_AUTHOR_AMY = "Block 312, Amy Street 1";
     public static final String VALID_AUTHOR_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TAG_HUSBAND = "husband";
@@ -50,7 +50,7 @@ public class CommandTestUtil {
 
     public static final String INVALID_TITLE_DESC = " " + PREFIX_TITLE + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
-    public static final String INVALID_GENRE_DESC = " " + PREFIX_GENRE + "bob!yahoo"; // missing '@' symbol
+    public static final String INVALID_GENRE_DESC = " " + PREFIX_GENRE;
     public static final String INVALID_AUTHOR_DESC = " " + PREFIX_AUTHOR; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 

--- a/src/test/java/seedu/library/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/library/logic/parser/ParserUtilTest.java
@@ -24,7 +24,7 @@ public class ParserUtilTest {
     private static final String INVALID_TITLE = "R@chel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_AUTHOR = " ";
-    private static final String INVALID_GENRE = "example.com";
+    private static final String INVALID_GENRE = " ";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_TITLE = "Rachel Walker";

--- a/src/test/java/seedu/library/model/bookmark/GenreTest.java
+++ b/src/test/java/seedu/library/model/bookmark/GenreTest.java
@@ -28,41 +28,8 @@ public class GenreTest {
         assertFalse(Genre.isValidGenre("")); // empty string
         assertFalse(Genre.isValidGenre(" ")); // spaces only
 
-        // missing parts
-        assertFalse(Genre.isValidGenre("@example.com")); // missing local part
-        assertFalse(Genre.isValidGenre("peterjackexample.com")); // missing '@' symbol
-        assertFalse(Genre.isValidGenre("peterjack@")); // missing domain name
-
-        // invalid parts
-        assertFalse(Genre.isValidGenre("peterjack@-")); // invalid domain name
-        assertFalse(Genre.isValidGenre("peterjack@exam_ple.com")); // underscore in domain name
-        assertFalse(Genre.isValidGenre("peter jack@example.com")); // spaces in local part
-        assertFalse(Genre.isValidGenre("peterjack@exam ple.com")); // spaces in domain name
-        assertFalse(Genre.isValidGenre(" peterjack@example.com")); // leading space
-        assertFalse(Genre.isValidGenre("peterjack@example.com ")); // trailing space
-        assertFalse(Genre.isValidGenre("peterjack@@example.com")); // double '@' symbol
-        assertFalse(Genre.isValidGenre("peter@jack@example.com")); // '@' symbol in local part
-        assertFalse(Genre.isValidGenre("-peterjack@example.com")); // local part starts with a hyphen
-        assertFalse(Genre.isValidGenre("peterjack-@example.com")); // local part ends with a hyphen
-        assertFalse(Genre.isValidGenre("peter..jack@example.com")); // local part has two consecutive periods
-        assertFalse(Genre.isValidGenre("peterjack@example@com")); // '@' symbol in domain name
-        assertFalse(Genre.isValidGenre("peterjack@.example.com")); // domain name starts with a period
-        assertFalse(Genre.isValidGenre("peterjack@example.com.")); // domain name ends with a period
-        assertFalse(Genre.isValidGenre("peterjack@-example.com")); // domain name starts with a hyphen
-        assertFalse(Genre.isValidGenre("peterjack@example.com-")); // domain name ends with a hyphen
-        assertFalse(Genre.isValidGenre("peterjack@example.c")); // top level domain has less than two chars
-
         // valid genre
-        assertTrue(Genre.isValidGenre("PeterJack_1190@example.com")); // underscore in local part
-        assertTrue(Genre.isValidGenre("PeterJack.1190@example.com")); // period in local part
-        assertTrue(Genre.isValidGenre("PeterJack+1190@example.com")); // '+' symbol in local part
-        assertTrue(Genre.isValidGenre("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Genre.isValidGenre("a@bc")); // minimal
-        assertTrue(Genre.isValidGenre("test@localhost")); // alphabets only
-        assertTrue(Genre.isValidGenre("123@145")); // numeric local part and domain name
-        assertTrue(Genre.isValidGenre("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
-        assertTrue(Genre.isValidGenre("peter_jack@very-very-very-long-example.com")); // long domain name
-        assertTrue(Genre.isValidGenre("if.you.dream.it_you.can.do.it@example.com")); // long local part
-        assertTrue(Genre.isValidGenre("e1234567@u.nus.edu")); // more than one period in domain
+        assertTrue(Genre.isValidGenre("Action"));
+        assertTrue(Genre.isValidGenre("-")); // one character
     }
 }

--- a/src/test/java/seedu/library/storage/JsonAdaptedBookmarkTest.java
+++ b/src/test/java/seedu/library/storage/JsonAdaptedBookmarkTest.java
@@ -21,7 +21,7 @@ public class JsonAdaptedBookmarkTest {
     private static final String INVALID_TITLE = "R@chel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_AUTHOR = " ";
-    private static final String INVALID_GENRE = "example.com";
+    private static final String INVALID_GENRE = " ";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_TITLE = BENSON.getTitle().toString();


### PR DESCRIPTION
The genre class was still being validated as if it was an email.

There was a need to change the validation regex for the genre class.
There was a need to update all invalid genre values in tests to correctly reflect an invalid genre instead of an invalid email.