### PR TITLE
Fix sort when rating not specified

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -446,10 +446,10 @@ no star logos would be displayed.
 #### Design considerations:
 
 ##### Aspect: How should `Rating` be stored?
-The `Rating` field is represented by integer values from 1 to 5. This allows for a simple and intuitive way to rate
+The `Rating` field is represented by integer values from 0 to 5. This allows for a simple and intuitive way to rate
 books in the `Library`.
 
-- **Alternative 1(current choice):** Representing it as an integer from 1 to 5 inclusive.
+- **Alternative 1(current choice):** Representing it as an integer from 0 to 5 inclusive.
   - Pros: Simple to keep track of and store, easily map rating to star icons in UI.
   - Cons: Might not be granular enough to represent all possible values.
 - **Alternative 2:** Representing it a decimal value from 0 to 5.

--- a/src/main/java/seedu/library/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/library/logic/parser/AddCommandParser.java
@@ -53,7 +53,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 : null;
         Rating rating = argMultimap.getValue(PREFIX_RATING).isPresent()
                 ? ParserUtil.parseRating(argMultimap.getValue(PREFIX_RATING).get())
-                : null;
+                : Rating.DEFAULT_RATING;
         Url url = argMultimap.getValue(PREFIX_URL).isPresent()
                 ? ParserUtil.parseUrl(argMultimap.getValue(PREFIX_URL).get())
                 : new Url("");

--- a/src/main/java/seedu/library/model/bookmark/Rating.java
+++ b/src/main/java/seedu/library/model/bookmark/Rating.java
@@ -11,9 +11,11 @@ public class Rating implements Comparable<Rating> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Rating should be integer value from 1 to 5(inclusive)";
-    public static final String VALIDATION_REGEX = "[1-5]";
+    public static final String VALIDATION_REGEX = "[0-5]";
 
     public final String value;
+
+    public static final Rating DEFAULT_RATING = new Rating("0");
 
     /**
      * Constructs a {@code Rating}.

--- a/src/main/java/seedu/library/model/bookmark/Rating.java
+++ b/src/main/java/seedu/library/model/bookmark/Rating.java
@@ -9,13 +9,13 @@ import static seedu.library.commons.util.AppUtil.checkArgument;
  */
 public class Rating implements Comparable<Rating> {
 
+    public static final Rating DEFAULT_RATING = new Rating("0");
+
     public static final String MESSAGE_CONSTRAINTS =
             "Rating should be integer value from 1 to 5(inclusive)";
     public static final String VALIDATION_REGEX = "[0-5]";
 
     public final String value;
-
-    public static final Rating DEFAULT_RATING = new Rating("0");
 
     /**
      * Constructs a {@code Rating}.

--- a/src/main/java/seedu/library/ui/BookmarkCard.java
+++ b/src/main/java/seedu/library/ui/BookmarkCard.java
@@ -14,6 +14,7 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.library.model.bookmark.Bookmark;
+import seedu.library.model.bookmark.Rating;
 
 /**
  * An UI component that displays information of a {@code Bookmark}.
@@ -120,7 +121,7 @@ public class BookmarkCard extends UiPart<Region> {
         InputStream rating4 = new FileInputStream("src/main/resources/images/Rating4.png");
         InputStream rating5 = new FileInputStream("src/main/resources/images/Rating5.png");
 
-        if (bookmark.getRating() == null) {
+        if (bookmark.getRating().equals(Rating.DEFAULT_RATING)) {
             ratingI.setImage(new Image(rating0));
             return;
         }

--- a/src/main/java/seedu/library/ui/ZoomView.java
+++ b/src/main/java/seedu/library/ui/ZoomView.java
@@ -147,11 +147,8 @@ public class ZoomView extends UiPart<Region> {
             } else {
                 ratingStar.setVisible(false);
             }
-
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             throw new AssertionError(e);
-
         }
 
     }

--- a/src/main/java/seedu/library/ui/ZoomView.java
+++ b/src/main/java/seedu/library/ui/ZoomView.java
@@ -147,7 +147,9 @@ public class ZoomView extends UiPart<Region> {
             } else {
                 ratingStar.setVisible(false);
             }
-        } catch (IOException e) {
+
+        }
+        catch (IOException e) {
             throw new AssertionError(e);
         }
 


### PR DESCRIPTION
Closes #188 

Currently when no rating is given, sorting does not work as the value is null.

Changed the default value to 0 so that comparing is possible.